### PR TITLE
fix ordering of recipes

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,5 +17,5 @@
 # limitations under the License.
 #
 
-include_recipe "php::default"
 include_recipe "osl-php::packages"
+include_recipe "php::default"


### PR DESCRIPTION
If we don't install the `osl-php` packages first, we can end up calling `php_pear` resources before pear is installed properly.
