### PR TITLE
Added test for included recipe in default.rb missing in default_spec.rb

### DIFF
--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -9,8 +9,10 @@ describe 'osl-php::default' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
-      it do
-        expect(chef_run).to include_recipe('php::default')
+      %w(osl-php::packages php::default).each do |r|
+        it do
+          expect(chef_run).to include_recipe(r)
+        end
       end
     end
   end


### PR DESCRIPTION
osl-php::packages inclusion was not tested in the ChefSpec tests for the default recipe, so this PR adds that test. 