### PR TITLE
Include php::ini in packages recipe.

### DIFF
--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -19,3 +19,5 @@
 node['osl-php']['packages'].each do |p|
   package p
 end
+
+include_recipe 'php::ini'


### PR DESCRIPTION
This is the fix discussed in #10. Marc from phpBB indicated that the differences in `bamboo1.phpbb.com`'s `php.ini` won't be an issue, and that what chef generates should be fine (in ticket 29428). So we should be all good to move forward with this.