### PR TITLE
Lock upstream cookbook to what we have in production

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -121,6 +121,7 @@ end
 
 desc 'Run RSpec (unit) tests'
 task :unit do
+    run_command('rm -f Berksfile.lock')
     run_command('rspec')
 end
 

--- a/libraries/support/matchers.rb
+++ b/libraries/support/matchers.rb
@@ -1,0 +1,6 @@
+if defined?(ChefSpec)
+  ChefSpec.define_matcher :php_pear
+  def install_php_pear(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:php_pear, :install, resource_name)
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,4 +13,4 @@ supports         'centos', '~> 7.0'
 
 depends          'build-essential'
 depends          'composer'
-depends          'php'
+depends          'php', '~> 1.2.6'

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -20,4 +20,4 @@ node['osl-php']['packages'].each do |p|
   package p
 end
 
-include_recipe 'php::ini'
+include_recipe 'php::package'


### PR DESCRIPTION
We're currently using version 1.2.6 in production and the newer version of the
upstream cookbook has a lot of changes. Later on we'll worry about updating to a
newer version of the cookbook.