### PR TITLE
Use php cookbook version 4.5.0.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,8 +6,11 @@ provisioner:
       disabled: true
     osl-php:
       packages:
+          - 'php'
+          - 'php-devel'
           - 'php-fpm'
           - 'php-gd'
+          - 'php-pear'
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,4 +13,4 @@ supports         'centos', '~> 7.0'
 
 depends          'build-essential'
 depends          'composer'
-depends          'php', '~> 1.2.6'
+depends          'php', '~> 4.5.0'

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-node['osl-php']['packages'].each do |p|
-  package p
+if node['osl-php']['packages'].any?
+  node.normal['php']['packages'] = node['osl-php']['packages']
 end
 
 include_recipe 'php::package'

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -5,14 +5,20 @@ describe 'osl-php::packages' do
     context "on #{pltfrm[:platform]} #{pltfrm[:version]}" do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(pltfrm) do |node|
-          node.set['osl-php']['packages'] = %w(php-fpm php-gd)
+          node.set['osl-php']['packages'] = %w(php
+                                               php-devel
+                                               php-fpm
+                                               php-gd
+                                               php-pear)
         end.converge(described_recipe)
       end
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
       it do
-        expect(chef_run).to install_package(%w(php-fpm php-gd))
+        expect(chef_run).to install_package(
+          chef_run.node['osl-php']['packages']
+        )
       end
     end
   end

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -11,10 +11,8 @@ describe 'osl-php::packages' do
       it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
-      %w(php-fpm php-gd).each do |pkg|
-        it do
-          expect(chef_run).to install_package(pkg)
-        end
+      it do
+        expect(chef_run).to install_package(%w(php-fpm php-gd))
       end
     end
   end

--- a/test/integration/packages/serverspec/packages_spec.rb
+++ b/test/integration/packages/serverspec/packages_spec.rb
@@ -2,10 +2,12 @@ require 'serverspec'
 
 set :backend, :exec
 
-describe package('php-fpm') do
-  it { should be_installed }
-end
-
-describe package('php-gd') do
-  it { should be_installed }
+%w(php
+   php-devel
+   php-fpm
+   php-gd
+   php-pear).each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
 end


### PR DESCRIPTION
This PR updates this cookbook to use the current master version of the `php` cookbook: 4.5.0.

This also includes a suggested change in `php::packages` which would allow us to use that recipe without having to remember to clear an attribute for an upstream cookbook (php). (This would require us to edit our usage of this recipe in two other cookbooks, though, to remove the clearing of the attribute. I'll make PRs for that if we decide to use it.)

~~I've been experiencing a bizarre dependency conflict in the `proj-phpbb` cookbook ever since the update to `osl-php` in `0.2.1`. With no success debugging it, Lance suggested just updating `osl-php` to the version used in the `phpbb` environment. That's what this PR is for.~~

~~The inclusion of `php::package` is switched back to `php::ini` because the packages in `node['php']['packages']` would conflict with the packages in `node['osl-php']['packages']` otherwise, so this includes only the bit we need (the `php.ini` file).~~

I identified `proj-deluge` and `proj-misc` as cookbooks that would be affected by this change, and ran the test suites for the affected recipes (`proj-deluge::php` and `proj-misc::web2`). They seem to be unaffected, although the referenced PR updates a test to no longer look for quotes in the `php.ini` template.

Two other cookbooks, `proj-facebook` and `orvsd_central` also depend on this cookbook, but they seem deprecated (or at least not in use), so I didn't test with them.

