### PR TITLE
Fix issue with pear and php72u

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -52,3 +52,13 @@ suites:
         use_ius: true
       php:
         version: '7.1'
+  - name: packages-php72
+    run_list:
+    - recipe[osl-php::packages]
+    attributes:
+      osl-php:
+        use_ius: true
+      php:
+        version: '7.2'
+    excludes:
+      - centos-6.9

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -19,11 +19,8 @@ if node['osl-php']['use_ius']
   include_recipe 'yum-ius'
 
   if node['php']['version'].to_f == 7.1
-    node['yum'].each_key do |repo|
-      next unless node['yum'][repo]['managed']
-      r = resources(yum_repository: repo)
-      r.exclude = [r.exclude, 'php72*'].reject(&:nil?).join(' ')
-    end
+    r = resources(yum_repository: 'ius')
+    r.exclude = [r.exclude, 'php72*'].reject(&:nil?).join(' ')
   end
 end
 

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -41,6 +41,7 @@ if packages.any? || node['osl-php']['use_ius']
   # Include pear package (pear1u for PHP 7.1+)
   package 'pear' do
     package_name version.to_f >= 7.1 ? 'pear1u' : prefix + '-pear'
+    options '--exclude php72u\*' if version.to_f == 7.1
   end
 
   node.default['php']['packages'] = packages

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -21,46 +21,50 @@ describe 'osl-php::packages' do
           expect(chef_run).to install_package('php-pear')
         end
       end
-
-      context 'using packages with versioned prefixes' do
-        cached(:chef_run) do
-          ChefSpec::SoloRunner.new(pltfrm) do |node|
-            node.set['php']['version'] = '7.1'
-            node.set['osl-php']['use_ius'] = true
-            node.set['osl-php']['php_packages'] = %w(devel cli)
-          end.converge(described_recipe)
-        end
-        it 'converges successfully' do
-          expect { chef_run }.to_not raise_error
-        end
-        it do
-          expect(chef_run).to install_package(
-            'php71u-devel, php71u-cli, php71u'
-          )
-        end
-        it do
-          expect(chef_run).to install_package('pear1u')
-        end
-      end
-      context 'old method for backwards compatability' do
-        cached(:chef_run) do
-          ChefSpec::SoloRunner.new(pltfrm) do |node|
-            node.set['php']['version'] = '7.1'
-            node.set['osl-php']['use_ius'] = true
-            node.set['osl-php']['packages'] =
-              %w(php71u-devel php71u-cli)
-          end.converge(described_recipe)
-        end
-        it 'converges successfully' do
-          expect { chef_run }.to_not raise_error
-        end
-        it do
-          expect(chef_run).to install_package(
-            'php71u-devel, php71u-cli, php71u'
-          )
-        end
-        it do
-          expect(chef_run).to install_package('pear1u')
+      %w(7.1 7.2).each do |version|
+        prefix = "php#{version.split('.').join}u"
+        context "using php #{version}" do
+          context 'using packages with versioned prefixes' do
+            cached(:chef_run) do
+              ChefSpec::SoloRunner.new(pltfrm) do |node|
+                node.set['php']['version'] = version
+                node.set['osl-php']['use_ius'] = true
+                node.set['osl-php']['php_packages'] = %w(devel cli)
+              end.converge(described_recipe)
+            end
+            it 'converges successfully' do
+              expect { chef_run }.to_not raise_error
+            end
+            it do
+              expect(chef_run).to install_package(
+                "#{prefix}-devel, #{prefix}-cli, #{prefix}"
+              )
+            end
+            it do
+              expect(chef_run).to install_package('pear')
+            end
+          end
+          context 'old method for backwards compatability' do
+            cached(:chef_run) do
+              ChefSpec::SoloRunner.new(pltfrm) do |node|
+                node.set['php']['version'] = version
+                node.set['osl-php']['use_ius'] = true
+                node.set['osl-php']['packages'] =
+                  %w(devel cli).map { |p| "#{prefix}-#{p}" }
+              end.converge(described_recipe)
+            end
+            it 'converges successfully' do
+              expect { chef_run }.to_not raise_error
+            end
+            it do
+              expect(chef_run).to install_package(
+                "#{prefix}-devel, #{prefix}-cli, #{prefix}"
+              )
+            end
+            it do
+              expect(chef_run).to install_package('pear')
+            end
+          end
         end
       end
     end

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -43,9 +43,13 @@ describe 'osl-php::packages' do
             it do
               expect(chef_run).to install_package('pear')
             end
-            if version == '7.1'
-              it do
+            it do
+              if version == '7.1'
                 expect(chef_run).to create_yum_repository('ius').with(
+                  exclude: 'php72*'
+                )
+              else
+                expect(chef_run).to_not create_yum_repository('ius').with(
                   exclude: 'php72*'
                 )
               end
@@ -71,9 +75,13 @@ describe 'osl-php::packages' do
             it do
               expect(chef_run).to install_package('pear')
             end
-            if version == '7.1'
-              it do
+            it do
+              if version == '7.1'
                 expect(chef_run).to create_yum_repository('ius').with(
+                  exclude: 'php72*'
+                )
+              else
+                expect(chef_run).to_not create_yum_repository('ius').with(
                   exclude: 'php72*'
                 )
               end

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -43,6 +43,13 @@ describe 'osl-php::packages' do
             it do
               expect(chef_run).to install_package('pear')
             end
+            if version == '7.1'
+              it do
+                expect(chef_run).to create_yum_repository('ius').with(
+                  exclude: 'php72*'
+                )
+              end
+            end
           end
           context 'old method for backwards compatability' do
             cached(:chef_run) do
@@ -63,6 +70,13 @@ describe 'osl-php::packages' do
             end
             it do
               expect(chef_run).to install_package('pear')
+            end
+            if version == '7.1'
+              it do
+                expect(chef_run).to create_yum_repository('ius').with(
+                  exclude: 'php72*'
+                )
+              end
             end
           end
         end

--- a/test/integration/packages-php72/serverspec/php72_spec.rb
+++ b/test/integration/packages-php72/serverspec/php72_spec.rb
@@ -1,0 +1,13 @@
+require 'serverspec'
+
+set :backend, :exec
+
+%w(mod_php72u
+   php72u-devel
+   php72u-fpm
+   php72u-gd
+   pear1u).each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
+end


### PR DESCRIPTION
`pear1u` installs php72u by default. This PR is meant to prevent that if the intended php version is 7.1.