### PR TITLE
Enable IUS Archive repo for PHP 5.6, 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Attributes
 ----------
+* `node['osl-php']['ius_archive_versions']` - A list tracking versions of PHP that have moved into IUS's archive repo. The recipe should be updated when new versions on this list reach EOL: https://ius.io/LifeCycle/#php
 * `node['osl-php']['use_ius']` - Use PHP packages from [IUS Community](https://ius.io/) repositories when true. Defaults
   to false.
 * `node['osl-php']['packages']` - PHP packages to install that don't begin with a PHP prefix ("php-", "php56u-",

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,5 @@
 default['osl-php']['packages'] = []
 default['osl-php']['php_packages'] = []
 default['osl-php']['use_ius'] = false
+# List PHP versions that require IUS archive repo: https://ius.io/LifeCycle/#php
+default['osl-php']['ius_archive_versions'] = %w(5.6 7.0)

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -15,7 +15,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 if node['osl-php']['use_ius']
+  # Enable IUS archive repo for PHP 5.6
+  node.default['yum']['ius-archive']['enabled'] = node['php']['version'].to_f == 5.6
+  node.default['yum']['ius-archive']['managed'] = node['php']['version'].to_f == 5.6
+
   include_recipe 'yum-ius'
 
   if node['php']['version'].to_f == 7.1

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -17,12 +17,13 @@
 # limitations under the License.
 
 # List PHP versions that require IUS archive repo: https://ius.io/LifeCycle/#php
-ius_archive_versions = %w(5.6 7.0)
+node.default['osl-php']['ius_archive_versions'] = %w(5.6 7.0)
 
 if node['osl-php']['use_ius']
   # Enable IUS archive repo for archived versions
-  node.default['yum']['ius-archive']['enabled'] = ius_archive_versions.include?(node['php']['version'])
-  node.default['yum']['ius-archive']['managed'] = ius_archive_versions.include?(node['php']['version'])
+  enable_ius_archive = node['osl-php']['ius_archive_versions'].include?(node['php']['version'])
+  node.default['yum']['ius-archive']['enabled'] = enable_ius_archive
+  node.default['yum']['ius-archive']['managed'] = enable_ius_archive
 
   include_recipe 'yum-ius'
 

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -16,10 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# List PHP versions that require IUS archive repo: https://ius.io/LifeCycle/#php
+ius_archive_versions = %w(5.6 7.0)
+
 if node['osl-php']['use_ius']
-  # Enable IUS archive repo for PHP 5.6
-  node.default['yum']['ius-archive']['enabled'] = node['php']['version'].to_f == 5.6
-  node.default['yum']['ius-archive']['managed'] = node['php']['version'].to_f == 5.6
+  # Enable IUS archive repo for archived versions
+  node.default['yum']['ius-archive']['enabled'] = ius_archive_versions.include?(node['php']['version'])
+  node.default['yum']['ius-archive']['managed'] = ius_archive_versions.include?(node['php']['version'])
 
   include_recipe 'yum-ius'
 

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -16,9 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# List PHP versions that require IUS archive repo: https://ius.io/LifeCycle/#php
-node.default['osl-php']['ius_archive_versions'] = %w(5.6 7.0)
-
 if node['osl-php']['use_ius']
   # Enable IUS archive repo for archived versions
   enable_ius_archive = node['osl-php']['ius_archive_versions'].include?(node['php']['version'])

--- a/test/integration/packages-php56/serverspec/php56_spec.rb
+++ b/test/integration/packages-php56/serverspec/php56_spec.rb
@@ -11,3 +11,7 @@ set :backend, :exec
     it { should be_installed }
   end
 end
+
+describe file '/etc/yum.repos.d/ius-archive.repo' do
+  its(:content) { should match(/^enabled=1$/) }
+end

--- a/test/integration/packages-php56/serverspec/php56_spec.rb
+++ b/test/integration/packages-php56/serverspec/php56_spec.rb
@@ -12,6 +12,11 @@ set :backend, :exec
   end
 end
 
-describe file '/etc/yum.repos.d/ius-archive.repo' do
-  its(:content) { should match(/^enabled=1$/) }
+%w(
+  ius
+  ius-archive
+).each do |repo|
+  describe file "/etc/yum.repos.d/#{repo}.repo" do
+    its(:content) { should match(/^enabled=1$/) }
+  end
 end

--- a/test/integration/packages-php70/serverspec/php70_spec.rb
+++ b/test/integration/packages-php70/serverspec/php70_spec.rb
@@ -11,3 +11,12 @@ set :backend, :exec
     it { should be_installed }
   end
 end
+
+%w(
+  ius
+  ius-archive
+).each do |repo|
+  describe file "/etc/yum.repos.d/#{repo}.repo" do
+    its(:content) { should match(/^enabled=1$/) }
+  end
+end

--- a/test/integration/packages-php71/serverspec/php71_spec.rb
+++ b/test/integration/packages-php71/serverspec/php71_spec.rb
@@ -11,3 +11,11 @@ set :backend, :exec
     it { should be_installed }
   end
 end
+
+describe file '/etc/yum.repos.d/ius.repo' do
+  its(:content) { should match(/^enabled=1$/) }
+end
+
+describe file '/etc/yum.repos.d/ius-archive.repo' do
+  it { should_not exist }
+end

--- a/test/integration/packages-php72/serverspec/php72_spec.rb
+++ b/test/integration/packages-php72/serverspec/php72_spec.rb
@@ -11,3 +11,11 @@ set :backend, :exec
     it { should be_installed }
   end
 end
+
+describe file '/etc/yum.repos.d/ius.repo' do
+  its(:content) { should match(/^enabled=1$/) }
+end
+
+describe file '/etc/yum.repos.d/ius-archive.repo' do
+  it { should_not exist }
+end

--- a/test/integration/packages/serverspec/packages_spec.rb
+++ b/test/integration/packages/serverspec/packages_spec.rb
@@ -11,3 +11,12 @@ set :backend, :exec
     it { should be_installed }
   end
 end
+
+%w(
+  ius
+  ius-archive
+).each do |repo|
+  describe file "/etc/yum.repos.d/#{repo}.repo" do
+    it { should_not exist }
+  end
+end


### PR DESCRIPTION
IUS has archived `php56*` packages, so I've updated the recipe to enable the IUS archive repo when using PHP 5.6.