### PR TITLE
Bring php-5.3 back from the dead

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,6 +28,14 @@ suites:
   - name: packages
     run_list:
     - recipe[osl-php::packages]
+  - name: packages-php53
+    run_list:
+    - recipe[osl-php::packages]
+    attributes:
+      osl-php:
+        use_ius: true
+      php:
+        version: '5.3'
   - name: packages-php56
     run_list:
     - recipe[osl-php::packages]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,4 +2,4 @@ default['osl-php']['packages'] = []
 default['osl-php']['php_packages'] = []
 default['osl-php']['use_ius'] = false
 # List PHP versions that require IUS archive repo: https://ius.io/LifeCycle/#php
-default['osl-php']['ius_archive_versions'] = %w(5.6 7.0)
+default['osl-php']['ius_archive_versions'] = %w(5.3 5.6 7.0)

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -22,6 +22,13 @@ if node['osl-php']['use_ius']
   node.default['yum']['ius-archive']['enabled'] = enable_ius_archive
   node.default['yum']['ius-archive']['managed'] = enable_ius_archive
 
+  # php53u RPMs built against CentOS 7
+  if node['php']['version'].to_f == 5.3 && node['platform_version'].to_i >= 7
+    node.default['yum']['ius']['gpgkey'] = 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl'
+    node.default['yum']['ius']['baseurl'] = 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/php53/$basearch'
+    node.default['yum']['ius']['mirrorlist'] = nil
+  end
+
   include_recipe 'yum-ius'
 
   if node['php']['version'].to_f == 7.1

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -21,7 +21,7 @@ describe 'osl-php::packages' do
           expect(chef_run).to install_package('php-pear')
         end
       end
-      %w(7.1 7.2).each do |version|
+      %w(5.3 5.6 7.1 7.2).each do |version|
         prefix = "php#{version.split('.').join}u"
         context "using php #{version}" do
           context 'using packages with versioned prefixes' do
@@ -44,14 +44,35 @@ describe 'osl-php::packages' do
               expect(chef_run).to install_package('pear')
             end
             it do
-              if version == '7.1'
-                expect(chef_run).to create_yum_repository('ius').with(
-                  exclude: 'php72*'
-                )
+              case version
+              when '5.3'
+                if pltfrm[:version].to_i >= 7
+                  expect(chef_run).to create_yum_repository('ius')
+                    .with(
+                      gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+                      baseurl: 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/php53/$basearch',
+                      mirrorlist: nil
+                    )
+                else
+                  expect(chef_run).to_not create_yum_repository('ius')
+                    .with(
+                      gpgkey: 'http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl',
+                      baseurl: 'http://ftp.osuosl.org/pub/osl/repos/yum/$releasever/php53/$basearch',
+                      mirrorlist: nil
+                    )
+                end
+              when '7.1'
+                expect(chef_run).to create_yum_repository('ius').with(exclude: 'php72*')
               else
-                expect(chef_run).to_not create_yum_repository('ius').with(
-                  exclude: 'php72*'
-                )
+                expect(chef_run).to_not create_yum_repository('ius').with(exclude: 'php72*')
+              end
+            end
+            it do
+              case version
+              when '5.3', '5.6', '7.0'
+                expect(chef_run).to create_yum_repository('ius-archive')
+              else
+                expect(chef_run).to_not create_yum_repository('ius-archive')
               end
             end
           end

--- a/test/integration/packages-php53/serverspec/php53_spec.rb
+++ b/test/integration/packages-php53/serverspec/php53_spec.rb
@@ -1,0 +1,33 @@
+require 'serverspec'
+
+set :backend, :exec
+
+%w(php53u
+   php53u-devel
+   php53u-fpm
+   php53u-gd
+   php53u-pear).each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
+end
+
+%w(
+  ius
+  ius-archive
+).each do |repo|
+  describe file "/etc/yum.repos.d/#{repo}.repo" do
+    its(:content) { should match(/^enabled=1$/) }
+    if repo == 'ius'
+      if os[:release].to_i >= 7
+        its(:content) { should match(%r{^baseurl=http://ftp.osuosl.org/pub/osl/repos/yum/\$releasever/php53/\$basearch$}) }
+        its(:content) { should match(%r{^gpgkey=http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl$}) }
+        its(:content) { should_not match(/^mirrorlist/) }
+      else
+        its(:content) { should_not match(%r{^baseurl=http://ftp.osuosl.org/pub/osl/repos/yum/\$releasever/php53/\$basearch$}) }
+        its(:content) { should_not match(%r{^gpgkey=http://ftp.osuosl.org/pub/osl/repos/yum/RPM-GPG-KEY-osuosl$}) }
+        its(:content) { should match(/^mirrorlist/) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need php-5.3 for an LF project so this brings back support for it.
Specifically, I built a set of php RPMs for CentOS 7 and published them on our
mirror. This adds support for running php 5.3 on CentOS 7 while 5.3 is still
accessible via the archive repo for CentOS 6.