### PR TITLE
Add support for PHP 7.3

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -70,6 +70,16 @@ suites:
         version: '7.2'
     excludes:
       - centos-6
+  - name: packages-php73
+    run_list:
+    - recipe[osl-php::packages]
+    attributes:
+      osl-php:
+        use_ius: true
+      php:
+        version: '7.3'
+    excludes:
+      - centos-6
   - name: php_ini
     run_list:
     - recipe[php_test::php_ini]

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -61,27 +61,18 @@ end
 
 # If any of our attributes are set, modify upstream packages attribute
 if packages.any? || node['osl-php']['use_ius']
-  packages <<= if version.to_f < 7.3
-                 # Prefix is also the name of the main PHP package until 7.3
+  packages <<= if version.to_f < 7
                  prefix
                else
-                 # When you install the main PHP package directly, like php72u, it's actually
-                 # installing the mod_php package. With the IUS PHP 7.3 packages, installing
-                 # php73 directly no longer works, so we have to explicitly install the
-                 # mod_php package. This may or may not be true for future IUS PHP packages.
-                 "mod_php#{version.split('.')[0, 2].join}"
+                 # When installing the main PHP (>= 7.0) package directly, like
+                 # php72u, it's actually installing the mod_php package, so we
+                 # explicitly do that here.
+                 "mod_#{prefix}"
                end
 
-  # Include pear package (pear1u for PHP 7.1+)
+  # Include pear package (pear1 for PHP 7.1+)
   package 'pear' do
-    vers = version.to_f
-    pkg_name = if vers > 7
-                 vers < 7.3 ? 'pear1u' : 'pear1'
-               else
-                 prefix + '-pear'
-               end
-
-    package_name pkg_name
+    package_name version.to_f >= 7.1 ? 'pear1' : prefix + '-pear'
   end
 
   node.default['php']['packages'] = packages

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -21,6 +21,30 @@ describe 'osl-php::packages' do
           expect(chef_run).to install_package('php-pear')
         end
       end
+      context 'using php 7.3' do
+        cached(:chef_run) do
+          ChefSpec::SoloRunner.new(pltfrm) do |node|
+            node.normal['php']['version'] = '7.3'
+            node.normal['osl-php']['use_ius'] = true
+            node.normal['osl-php']['php_packages'] = %w(devel cli)
+          end.converge(described_recipe)
+        end
+        it 'converges successfully' do
+          expect { chef_run }.to_not raise_error
+        end
+        it do
+          expect(chef_run).to install_package('php73-devel, php73-cli, mod_php73')
+        end
+        it do
+          expect(chef_run).to install_package('pear').with(package_name: 'pear1')
+        end
+        it do
+          expect(chef_run).to create_yum_repository('ius')
+        end
+        it do
+          expect(chef_run).to_not create_yum_repository('ius-archive')
+        end
+      end
       %w(5.3 5.6 7.1 7.2).each do |version|
         prefix = "php#{version.split('.').join}u"
         context "using php #{version}" do

--- a/test/integration/packages-php73/inspec/php73_spec.rb
+++ b/test/integration/packages-php73/inspec/php73_spec.rb
@@ -1,8 +1,6 @@
-%w(mod_php73
-   php73-devel
-   php73-fpm
-   php73-gd
-   pear1).each do |pkg|
+%w(
+  mod_php73 php73-devel php73-fpm php73-gd pear1
+).each do |pkg|
   describe package(pkg) do
     it { should be_installed }
   end

--- a/test/integration/packages-php73/inspec/php73_spec.rb
+++ b/test/integration/packages-php73/inspec/php73_spec.rb
@@ -1,0 +1,22 @@
+%w(mod_php73
+   php73-devel
+   php73-fpm
+   php73-gd
+   pear1).each do |pkg|
+  describe package(pkg) do
+    it { should be_installed }
+  end
+end
+
+describe yum.repo 'ius' do
+  it { should be_enabled }
+end
+
+describe file '/etc/yum.repos.d/ius.repo' do
+  it { should exist }
+end
+
+describe yum.repo 'ius-archive' do
+  it { should_not exist }
+  it { should_not be_enabled }
+end


### PR DESCRIPTION
For the Snowdrift CiviCRM site, I figured I would use the latest version of PHP (7.3). Adding support for it was a bit more work than I expected. The IUS repo removed the 'u' at the end of the prefix in its 7.3 packages, and the prefix (php73) no longer refers to a valid package. I think this is why – php73 isn't a feature provided by the mod_php73 package like php72u is in mod_php72u:

```console
# repoquery --provides mod_php72u
mod_php = 7.2.24-1.el7.ius
mod_php(x86-64) = 7.2.24-1.el7.ius
mod_php72u = 7.2.24-1.el7.ius
mod_php72u(x86-64) = 7.2.24-1.el7.ius
php = 7.2.24-1.el7.ius
php(httpd)
php(x86-64) = 7.2.24-1.el7.ius
php-zts = 7.2.24-1.el7.ius
php-zts(x86-64) = 7.2.24-1.el7.ius
php72u = 7.2.24-1.el7.ius
php72u(x86-64) = 7.2.24-1.el7.ius
php72u-zts = 7.2.24-1.el7.ius
php72u-zts(x86-64) = 7.2.24-1.el7.ius

# repoquery --provides mod_php73
config(mod_php73) = 7.3.11-1.el7.ius
libphp7.so()(64bit)
mod_php = 7.3.11-1.el7.ius
mod_php(x86-64) = 7.3.11-1.el7.ius
mod_php73 = 7.3.11-1.el7.ius
mod_php73(x86-64) = 7.3.11-1.el7.ius
php = 7.3.11-1.el7.ius
php(httpd)
php(x86-64) = 7.3.11-1.el7.ius
```

Since installing the prefix (like php72u) was just installing mod_php72u anyway, the code installs mod_php73 directly for PHP versions >= 7.3 instead of php73.