### PR TITLE
Workaround for ImageMagick on CentOS 7 with ius-archive

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,7 @@ provisioner:
         - 'devel'
         - 'fpm'
         - 'gd'
+        - 'pecl-imagick'
 
 suites:
   - name: default
@@ -29,12 +30,22 @@ suites:
   - name: packages
     run_list:
     - recipe[osl-php::packages]
+    attributes:
+      osl-php:
+        php_packages:
+          - 'devel'
+          - 'fpm'
+          - 'gd'
   - name: packages-php53
     run_list:
     - recipe[osl-php::packages]
     attributes:
       osl-php:
         use_ius: true
+        php_packages:
+          - 'devel'
+          - 'fpm'
+          - 'gd'
       php:
         version: '5.3'
     excludes:

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,4 +15,6 @@ supports         'centos', '~> 6.0'
 
 depends          'composer'
 depends          'php', '~> 6.1.1'
+depends          'yum-centos'
 depends          'yum-ius', '~> 3.1.0'
+depends          'yum-osuosl'

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -96,6 +96,40 @@ describe 'osl-php::packages' do
                 end
               end
             end
+            if pltfrm == CENTOS_7
+              case php_version
+              when '5.3', '5.6', '7.0', '7.1'
+                it do
+                  expect(chef_run).to include_recipe('yum-centos')
+                end
+                it do
+                  expect(chef_run).to include_recipe('yum-osuosl')
+                end
+                it do
+                  expect(chef_run).to create_yum_repository('base').with(exclude: 'ImageMagick*')
+                end
+              else
+                it do
+                  expect(chef_run).to_not include_recipe('yum-centos')
+                end
+                it do
+                  expect(chef_run).to_not include_recipe('yum-osuosl')
+                end
+                it do
+                  expect(chef_run).to_not create_yum_repository('base').with(exclude: 'ImageMagick*')
+                end
+              end
+            else
+              it do
+                expect(chef_run).to_not include_recipe('yum-centos')
+              end
+              it do
+                expect(chef_run).to_not include_recipe('yum-osuosl')
+              end
+              it do
+                expect(chef_run).to_not create_yum_repository('base').with(exclude: 'ImageMagick*')
+              end
+            end
           end
           context 'old method for backwards compatability' do
             cached(:chef_run) do

--- a/test/integration/packages-php56/inspec/php56_spec.rb
+++ b/test/integration/packages-php56/inspec/php56_spec.rb
@@ -4,6 +4,7 @@
   php56u-fpm
   php56u-gd
   php56u-pear
+  php56u-pecl-imagick
 ).each do |pkg|
   describe package(pkg) do
     it { should be_installed }

--- a/test/integration/packages-php70/inspec/php70_spec.rb
+++ b/test/integration/packages-php70/inspec/php70_spec.rb
@@ -4,6 +4,7 @@
   php70u-fpm
   php70u-gd
   php70u-pear
+  php70u-pecl-imagick
 ).each do |pkg|
   describe package(pkg) do
     it { should be_installed }

--- a/test/integration/packages-php71/inspec/php71_spec.rb
+++ b/test/integration/packages-php71/inspec/php71_spec.rb
@@ -1,8 +1,9 @@
 %w(mod_php71u
+   pear1
    php71u-devel
    php71u-fpm
    php71u-gd
-   pear1
+   php71u-pecl-imagick
 ).each do |pkg|
   describe package(pkg) do
     it { should be_installed }

--- a/test/integration/packages-php72/inspec/php72_spec.rb
+++ b/test/integration/packages-php72/inspec/php72_spec.rb
@@ -26,10 +26,11 @@ if os.release.to_i >= 8
 else
   %w(
     mod_php72u
+    pear1
     php72u-devel
     php72u-fpm
     php72u-gd
-    pear1
+    php72u-pecl-imagick
   ).each do |pkg|
     describe package(pkg) do
       it { should be_installed }

--- a/test/integration/packages-php73/inspec/php73_spec.rb
+++ b/test/integration/packages-php73/inspec/php73_spec.rb
@@ -1,5 +1,10 @@
 %w(
-  mod_php73 php73-devel php73-fpm php73-gd pear1
+  mod_php73
+  pear1
+  php73-devel
+  php73-fpm
+  php73-gd
+  php73-pecl-imagick
 ).each do |pkg|
   describe package(pkg) do
     it { should be_installed }


### PR DESCRIPTION
The update to CentOS 7.8 has broken the ius-archive repositories since it
updated the version of ImageMagick. This will work around that issue by pulling
in the version from CentOS 7.7 and excluding it from newer the upstream repos.