### PR TITLE
Update php bash helpers

### DIFF
--- a/files/default/phpcheck
+++ b/files/default/phpcheck
@@ -3,25 +3,29 @@
 SEARCHDIR=/var/www
 
 function show_help () {
-  echo "phpcheck / phpshow help:"
-  echo
-  echo "These are a couple of aliases to check a directory's php files for a regex expression."
-  echo "Intended to help find depreciated functions, etc."
-  echo
-  echo "phpcheck will show just the immediate subdirs that have files that match the regex."
-  echo
-  echo "phpshow will show all offending lines, but can be hard to deciper if there are a lot of matches."
-  echo
-  echo "Recommended use is:"
-  echo "- use phpcheck in /var/www/ to find sites with problems"
-  echo "- use phpshow in individual webroots to see some context around each match"
-  echo
-  echo "Note: 'geshi' directories are excluded as Geshi is a syntax highlighter and will most likely"
-  echo " throw false positives from its php highlighting."
-  echo
-  echo "ARGUMENTS:"
-  echo "  -h: show this help message"
-  echo "  -d DIR: look in DIR instead of current directory"
+  cat <<- "  EOH"
+	phpcheck help:
+
+	ARGUMENTS:
+	  -h:     show this help message
+	  -d DIR: look in DIR instead of current directory
+
+	USAGE:
+	  phpshow -d DIR 'regex'
+
+	phpcheck and phpshow are a couple of aliases to check a directory's php files for a regex expression.
+	These are intended to help find depreciated functions, etc.
+
+	phpcheck will show just the immediate subdirs that have files that match the regex.
+	phpshow will show all offending lines, but can be hard to deciper if there are a lot of matches.
+
+	Recommended use is:
+	- use phpcheck in /var/www/ to find sites with problems
+	- use phpshow in individual webroots to see some context around each match
+
+	Note: 'geshi' directories are excluded as Geshi is a syntax highlighter and will most likely
+	throw false positives from its php highlighting.
+  EOH
 
   exit 0
 }
@@ -40,4 +44,4 @@ while getopts ":hd:" opt; do
 done
 shift $((OPTIND -1)) # remove args handled by getopt
 
-find "$SEARCHDIR" -name '*.php' -or -name '*.ini' | grep -v '/geshi/' | xargs grep -H -T -e "$*" | sed "s/^${SEARCHDIR//\//\\/}//" | cut -d/ -f2 | uniq
+find "$SEARCHDIR" -type f -name '*.php' -or -name '*.ini' | grep -v '/geshi/' | xargs grep -H -T -e "$*" | sed "s/^${SEARCHDIR//\//\\/}//" | cut -d/ -f2 | uniq

--- a/files/default/phpshow
+++ b/files/default/phpshow
@@ -3,25 +3,29 @@
 SEARCHDIR=/var/www
 
 function show_help () {
-  echo "phpcheck / phpshow help:"
-  echo
-  echo "These are a couple of aliases to check a directory's php files for a regex expression."
-  echo "Intended to help find depreciated functions, etc."
-  echo
-  echo "phpcheck will show just the immediate subdirs that have files that match the regex."
-  echo
-  echo "phpshow will show all offending lines, but can be hard to deciper if there are a lot of matches."
-  echo
-  echo "Recommended use is:"
-  echo "- use phpcheck in /var/www/ to find sites with problems"
-  echo "- use phpshow in individual webroots to see some context around each match"
-  echo
-  echo "Note: 'geshi' directories are excluded as Geshi is a syntax highlighter and will most likely"
-  echo " throw false positives from its php highlighting."
-  echo
-  echo "ARGUMENTS:"
-  echo "  -h: show this help message"
-  echo "  -d DIR: look in DIR instead of current directory"
+  cat <<- "  EOH"
+	phpshow help:
+
+	ARGUMENTS:
+	  -h:     show this help message
+	  -d DIR: look in DIR instead of current directory
+
+	USAGE:
+	  phpshow -d DIR 'regex'
+
+	phpcheck and phpshow are a couple of aliases to check a directory's php files for a regex expression.
+	These are intended to help find depreciated functions, etc.
+
+	phpcheck will show just the immediate subdirs that have files that match the regex.
+	phpshow will show all offending lines, but can be hard to deciper if there are a lot of matches.
+
+	Recommended use is:
+	- use phpcheck in /var/www/ to find sites with problems
+	- use phpshow in individual webroots to see some context around each match
+
+	Note: 'geshi' directories are excluded as Geshi is a syntax highlighter and will most likely
+	throw false positives from its php highlighting.
+  EOH
 
   exit 0
 }
@@ -40,4 +44,4 @@ while getopts ":hd:" opt; do
 done
 shift $((OPTIND -1)) # remove args handled by getopt
 
-find "$SEARCHDIR" -name '*.php' -or -name '*.ini' | grep -v '/geshi/' | xargs grep --color=auto -H -T -e "$*"
+find "$SEARCHDIR" -type f -name '*.php' -or -name '*.ini' | grep -v '/geshi/' | xargs grep --color=auto -HnT -e "$*"

--- a/spec/php_test/php_ini_spec.rb
+++ b/spec/php_test/php_ini_spec.rb
@@ -12,7 +12,7 @@ describe 'php_test::php_ini' do
       %w(
         no_sections_rendered
         with_sections_rendered
-        no_sections_rendered_removed
+        no_sections_rendered_added
       ).each do |name|
         it do
           expect(chef_run).to create_directory("/etc/php.d #{name}").with(path: '/etc/php.d')

--- a/test/cookbooks/php_test/recipes/php_ini.rb
+++ b/test/cookbooks/php_test/recipes/php_ini.rb
@@ -110,8 +110,7 @@ php_ini 'no_sections_rendered' do
   options no_sections
 end
 
-php_ini 'no_sections_rendered_removed_add_action' do
-  name 'no_sections_rendered_removed'
+php_ini 'no_sections_rendered_added' do
   options no_sections
 end
 

--- a/test/integration/default/inspec/default_spec.rb
+++ b/test/integration/default/inspec/default_spec.rb
@@ -19,11 +19,11 @@ describe file('/usr/local/bin/phpshow') do
 end
 
 describe command('/usr/local/bin/phpcheck -h') do
-  its('stdout') { should match 'phpcheck / phpshow help:' }
+  its('stdout') { should match 'phpcheck help:' }
 end
 
 describe command('/usr/local/bin/phpshow -h') do
-  its('stdout') { should match 'phpcheck / phpshow help:' }
+  its('stdout') { should match 'phpshow help:' }
 end
 
 describe command('/usr/local/bin/phpcheck test for me') do
@@ -32,6 +32,6 @@ describe command('/usr/local/bin/phpcheck test for me') do
 end
 
 describe command('/usr/local/bin/phpshow test for me') do
-  its('stdout') { should match %r{phphelpertest/test_file.php.+test for me!} }
-  its('stdout') { should match %r{test_the_second/me_too.php.+test for me too!} }
+  its('stdout') { should match %r{phphelpertest/test_file.php.+1.+test for me!} }
+  its('stdout') { should match %r{test_the_second/me_too.php.+1.+test for me too!} }
 end


### PR DESCRIPTION
Found a couple minor issues when using the new helpers on `web2`.

- Only search for files (previously would also find directories)
- Show line numbers for `phpshow`
- Use heredocs for help message instead of a wall of `echo`s