### PR TITLE
Fix disabling ius-archive when switching between versions

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -2,7 +2,7 @@
 verifier:
   name: inspec
 provisioner:
-  name: chef_solo
+  name: chef_zero
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -20,12 +20,13 @@ if node['osl-php']['use_ius'] && node['platform_version'].to_i < 8
   # Enable IUS archive repo for archived versions
   enable_ius_archive = node['osl-php']['ius_archive_versions'].any? { |v| node['php']['version'].start_with?(v) }
   node.default['yum']['ius-archive']['enabled'] = enable_ius_archive
-  node.default['yum']['ius-archive']['managed'] = enable_ius_archive
+  node.default['yum']['ius-archive']['managed'] = true
+
+  include_recipe 'yum-centos'
+  include_recipe 'yum-osuosl'
 
   # CentOS 7.8 updated ImageMagick which broke installations from ius-archive
   if enable_ius_archive && node['platform_version'].to_i >= 7
-    include_recipe 'yum-centos'
-    include_recipe 'yum-osuosl'
 
     # Exclude all ImageMagick packages from the CentOS repos
     node['yum-centos']['repos'].each do |repo|

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -76,31 +76,25 @@ describe 'osl-php::packages' do
               else
                 case php_version
                 when '5.6', '7.1'
-                  expect(chef_run).to create_yum_repository('ius-archive')
+                  expect(chef_run).to create_yum_repository('ius-archive').with(enabled: true)
                 else
-                  expect(chef_run).to_not create_yum_repository('ius-archive')
+                  expect(chef_run).to create_yum_repository('ius-archive').with(enabled: false)
                 end
               end
             end
             if pltfrm == CENTOS_7
+              it do
+                expect(chef_run).to include_recipe('yum-centos')
+              end
+              it do
+                expect(chef_run).to include_recipe('yum-osuosl')
+              end
               case php_version
               when '5.6', '7.1'
-                it do
-                  expect(chef_run).to include_recipe('yum-centos')
-                end
-                it do
-                  expect(chef_run).to include_recipe('yum-osuosl')
-                end
                 it do
                   expect(chef_run).to create_yum_repository('base').with(exclude: 'ImageMagick*')
                 end
               else
-                it do
-                  expect(chef_run).to_not include_recipe('yum-centos')
-                end
-                it do
-                  expect(chef_run).to_not include_recipe('yum-osuosl')
-                end
                 it do
                   expect(chef_run).to_not create_yum_repository('base').with(exclude: 'ImageMagick*')
                 end

--- a/test/integration/packages-php72/inspec/php72_spec.rb
+++ b/test/integration/packages-php72/inspec/php72_spec.rb
@@ -49,6 +49,5 @@ else
 end
 
 describe yum.repo 'ius-archive' do
-  it { should_not exist }
   it { should_not be_enabled }
 end

--- a/test/integration/packages-php73/inspec/php73_spec.rb
+++ b/test/integration/packages-php73/inspec/php73_spec.rb
@@ -20,6 +20,5 @@ describe file '/etc/yum.repos.d/ius.repo' do
 end
 
 describe yum.repo 'ius-archive' do
-  it { should_not exist }
   it { should_not be_enabled }
 end

--- a/test/integration/packages-php74/inspec/php74_spec.rb
+++ b/test/integration/packages-php74/inspec/php74_spec.rb
@@ -19,6 +19,5 @@ describe file '/etc/yum.repos.d/ius.repo' do
 end
 
 describe yum.repo 'ius-archive' do
-  it { should_not exist }
   it { should_not be_enabled }
 end


### PR DESCRIPTION
We were incorrectly setting `managed` to `false` for ius-archive which affects
usage when migrating between IUS 5.6 AND 7.x packages. This properly fixes it by
still managing the ius-archive repo but properly disabling it when we need to.