### PR TITLE
Update to cookbook use php 8.0

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,12 @@
+module OslPhp
+  module Cookbook
+    module Helpers
+      def system_php?
+        # If didn't change this to 7.2 or 7.3, etc then let's assume we're using the system php package
+        node['php']['version'].match?(/\d+\.\d+\.\d+/)
+      end
+    end
+  end
+end
+Chef::DSL::Recipe.include ::OslPhp::Cookbook::Helpers
+Chef::Resource.include ::OslPhp::Cookbook::Helpers

--- a/libraries/support/matchers.rb
+++ b/libraries/support/matchers.rb
@@ -1,6 +1,0 @@
-if defined?(ChefSpec)
-  ChefSpec.define_matcher :php_pear
-  def install_php_pear(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:php_pear, :install, resource_name)
-  end
-end

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ supports         'centos', '~> 8.0'
 supports         'centos', '~> 7.0'
 
 depends          'composer'
-depends          'php', '~> 7.1.0'
+depends          'php', '~> 8.0.1'
 depends          'yum-centos'
 depends          'yum-epel'
 depends          'yum-ius', '~> 3.1.0'

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -84,7 +84,7 @@ end
 
 # If any of our attributes are set, modify upstream packages attribute
 if packages.any? || node['osl-php']['use_ius']
-  packages <<= if version.to_f < 7
+  packages <<= if system_php? || version.to_f < 7
                  prefix
                elsif node['platform_version'].to_i >= 8
                  'php'
@@ -97,7 +97,7 @@ if packages.any? || node['osl-php']['use_ius']
 
   # Include pear package (pear1 for PHP 7.1+)
   pear_pkg =
-    if node['platform_version'].to_i >= 8
+    if system_php? || node['platform_version'].to_i >= 8
       'php-pear'
     elsif version.to_f >= 7.1
       'pear1'

--- a/test/cookbooks/php_test/recipes/phpinfo_apache.rb
+++ b/test/cookbooks/php_test/recipes/phpinfo_apache.rb
@@ -1,4 +1,9 @@
-major_version = node['platform_version'].to_i < 8 ? node['php']['version'].to_i : 7
+major_version =
+  if system_php?
+    node['platform_version'].to_i < 8 ? '5' : 7
+  else
+    node['php']['version'].to_i
+  end
 
 ::Chef::Resource.include Apache2::Cookbook::Helpers
 


### PR DESCRIPTION
This makes a few adjustments so that this wrapper cookbooks works better with the Sous Chefs cookbook.

This update is required to use the newer nagios cookbook in osl-nagios.

- Create a new `system_php?` helper which checks to see if the `node['php']['version']` has a full semver which means we're likely using the system python. We typically only change this to be "7.x" not "7.x.x"
- Remove old ChefSpec matcher
