### PR TITLE
Fix default IUS installation if we don't explictly set node['php']['version']

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -42,6 +42,19 @@ suites:
           - 'devel'
           - 'fpm'
           - 'gd'
+  - name: packages-php-ius
+    run_list:
+    - recipe[osl-php::packages]
+    attributes:
+      osl-php:
+        use_ius: true
+    excludes:
+      - centos-8
+    verifier:
+      inspec_tests:
+        - test/integration/packages
+      inputs:
+        version: '7.4'
   - name: packages-php56
     run_list:
     - recipe[osl-php::packages]


### PR DESCRIPTION
With the recent update to `node['php']['version']` in the php cookbook, the logic we use has been broken when installing IUS. This provides fixes and a few assumptions when installing IUS without explictly setting `node['php']['version']`.

- Assume we're installing php74 if we don't set `node['php']['version']`
- If `system_php?` is true, don't try and enable ius-archive since we know it will be the latest version
- Don't use php version logic if we're using IUS and `system_php?` is true
- Add suite which tests that this is working properly (which we hadn't before)
