### PR TITLE
Allow pecl-imagick for php7.4 on CentOS 7

### DIFF
--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -87,8 +87,8 @@ packages += node['osl-php']['packages'].flatten
 if node['osl-php']['php_packages'].any?
   osl_packages = []
   osl_packages = osl_packages.concat(node['osl-php']['php_packages'])
-  # pecl-imagick is not available for php7.4 or CentOS 8
-  if (node['platform_version'].to_i >= 8 || prefix == 'php74') && osl_packages.include?('pecl-imagick')
+  # pecl-imagick is not available for php7.4 on CentOS 8
+  if node['platform_version'].to_i >= 8 && prefix == 'php74' && osl_packages.include?('pecl-imagick')
     osl_packages.delete_if { |pkg| pkg == 'pecl-imagick' }
   end
   packages += osl_packages.map { |pkg| prefix + '-' + pkg }

--- a/test/integration/packages/controls/packages_control.rb
+++ b/test/integration/packages/controls/packages_control.rb
@@ -112,6 +112,7 @@ control 'packages' do
               php74-devel
               php74-fpm
               php74-gd
+              php74-pecl-imagick
             )
           end
     describe yum.repo 'ius' do


### PR DESCRIPTION
This allows the `php74-pecl-imagick` package to be installed on CentOS 7. I've confirmed that the `php74-pecl-imagick` package is still not available on CentOS 8.

```
[centos@web1centos7-andrewda-greenworkstationcassore-kw70rtb ~]$ yum list installed | grep imagick
php74-pecl-imagick.x86_64              3.4.4-4.el7.ius                 @ius
```