### PR TITLE
Set the default timezone to UTC

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,10 @@ include_recipe 'osl-php::opcache' if node['osl-php']['use_opcache']
 include_recipe 'osl-php::packages'
 include_recipe 'php::default'
 
+php_ini 'timezone' do
+  options('date.timezone' => 'UTC')
+end
+
 %w(phpcheck phpshow).each do |file|
   cookbook_file "/usr/local/bin/#{file}" do
     source file

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -15,6 +15,9 @@ describe 'osl-php::default' do
         end
       end
       it do
+        expect(chef_run).to add_php_ini('timezone').with(options: { 'date.timezone' => 'UTC' })
+      end
+      it do
         expect(chef_run).to_not include_recipe('osl-php::opcache')
       end
     end

--- a/test/integration/default/controls/default_control.rb
+++ b/test/integration/default/controls/default_control.rb
@@ -14,6 +14,12 @@ control 'php_packages' do
     end
   end
 
+  describe command 'php -i' do
+    its('stdout') { should match '/etc/php.d/timezone.ini' }
+    its('stdout') { should match 'date.timezone => UTC => UTC' }
+    its('stdout') { should match 'Default timezone => UTC' }
+  end
+
   describe file('/usr/local/bin/phpcheck') do
     it { should exist }
     it { should be_executable }


### PR DESCRIPTION
This should reduce a lot of warnings we see on hosts. We can still override this if we need to per vhost.

Signed-off-by: Lance Albertson <lance@osuosl.org>
