### PR TITLE
Add composer pin to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version          '6.1.0'
 supports         'centos', '~> 7.0'
 supports         'centos_stream', '~> 8.0'
 
-depends          'composer', '~> 3.0.0'
+depends          'composer', '~> 3.0'
 depends          'osl-repos'
 depends          'osl-selinux'
 depends          'php', '~> 9.1.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version          '6.1.0'
 supports         'centos', '~> 7.0'
 supports         'centos_stream', '~> 8.0'
 
-depends          'composer'
+depends          'composer', '~> 3.0.0'
 depends          'osl-repos'
 depends          'osl-selinux'
 depends          'php', '~> 9.1.0'

--- a/spec/composer_spec.rb
+++ b/spec/composer_spec.rb
@@ -6,28 +6,37 @@ describe 'osl-php::composer' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(pltfrm).converge(described_recipe)
       end
-      it 'converges successfully' do
+
+      before do
+        stub_command('php --version').and_return('PHP 7.4.28')
         stub_command("php -m | grep 'Phar'").and_return(false)
+      end
+
+      it 'converges successfully' do
         expect { chef_run }.to_not raise_error
       end
+
       it do
         expect(chef_run.node['composer']['url']).to eq('https://getcomposer.org/download/1.10.7/composer.phar')
       end
+
       %w(php::default composer::default osl-selinux::default).each do |r|
         it do
           expect(chef_run).to include_recipe(r)
         end
       end
+
       context 'install different version' do
         cached(:chef_run) do
           ChefSpec::SoloRunner.new(pltfrm) do |node|
             node.normal['osl-php']['composer_version'] = '1.2.1'
           end.converge(described_recipe)
         end
+
         it 'converges successfully' do
-          stub_command("php -m | grep 'Phar'").and_return(false)
           expect { chef_run }.to_not raise_error
         end
+
         it do
           expect(chef_run.node['composer']['url']).to eq('https://getcomposer.org/download/1.2.1/composer.phar')
         end


### PR DESCRIPTION
This cookbook doesn't pin the `composer` cookbook, and probably should.

This will update `composer` to the latest 3.0.0 version as well.