### PR TITLE
Helper methods for setting php-fpm servers base on memory

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -5,6 +5,45 @@ module OslPhp
         # If didn't change this to 7.2 or 7.3, etc then let's assume we're using the system php package
         node['php']['version'].match?(/\d+\.\d+\.\d+/)
       end
+
+      def osl_php_available_ram
+        total_ram = (node['memory']['total'].split('kB')[0].to_i / 1024) # in MB
+        reserved_ram = 1024
+        buffer = total_ram * 0.1
+
+        # [Total Available RAM] - [Reserved RAM] - [10% buffer] = [Available RAM for PHP]
+        php_ram = (total_ram - reserved_ram - buffer).floor
+        # If we get a negative number, just make it zero
+        if php_ram < 0
+          0
+        else
+          php_ram
+        end
+      end
+
+      # process_size: in MB
+      def osl_php_fpm_settings(process_size)
+        # https://chrismoore.ca/2018/10/finding-the-correct-pm-max-children-settings-for-php-fpm/
+        # https://github.com/spot13/pmcalculator
+
+        # Run the following to figure the RSS size of php-fpm: ps -ylC php-fpm
+        # [Available RAM for PHP] / [Average Process Size] = [max_children]
+        max_children = (osl_php_available_ram / process_size).floor
+
+        # If we have zero, just a minimum of 4
+        max_children = 4 if max_children == 0
+
+        start_servers = (max_children * 0.25).floor
+        min_spare_servers = (max_children * 0.25).floor
+        max_spare_servers = (max_children * 0.75).floor
+
+        {
+          'max_children' => max_children,
+          'start_servers' => start_servers,
+          'min_spare_servers' => min_spare_servers,
+          'max_spare_servers' => max_spare_servers,
+        }
+      end
     end
   end
 end

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -1,0 +1,44 @@
+require_relative '../../spec_helper'
+require_relative '../../../libraries/helpers'
+
+RSpec.describe OslPhp::Cookbook::Helpers do
+  class DummyClass < Chef::Node
+    include OslPhp::Cookbook::Helpers
+  end
+
+  subject { DummyClass.new }
+
+  describe '#osl_php_available_ram' do
+    it '1G ram' do
+      allow(subject).to receive(:[]).with('memory').and_return({ 'total' => '1048576kB' })
+      expect(subject.osl_php_available_ram).to eq 0
+    end
+
+    it '4G ram' do
+      allow(subject).to receive(:[]).with('memory').and_return({ 'total' => '4194304kB' })
+      expect(subject.osl_php_available_ram).to eq 2662
+    end
+  end
+
+  describe '#osl_php_fpm_settings' do
+    it '1G ram' do
+      allow(subject).to receive(:[]).with('memory').and_return({ 'total' => '1048576kB' })
+      expect(subject.osl_php_fpm_settings(52)).to eq({
+        'max_children' => 4,
+        'max_spare_servers' => 3,
+        'min_spare_servers' => 1,
+        'start_servers' => 1,
+      })
+    end
+
+    it '4G ram' do
+      allow(subject).to receive(:[]).with('memory').and_return({ 'total' => '4194304kB' })
+      expect(subject.osl_php_fpm_settings(52)).to eq({
+        'max_children' => 51,
+        'max_spare_servers' => 38,
+        'min_spare_servers' => 12,
+        'start_servers' => 12,
+      })
+    end
+  end
+end


### PR DESCRIPTION
This utilizes [1][2] to determine the proper amount of servers to run with php-fpm. This is based on the amount of total memory and the average size of the php-fpm process.

These methods do not take into account if you're running multiple php-fpm servers at the same time.

[1] https://github.com/spot13/pmcalculator
[2] https://chrismoore.ca/2018/10/finding-the-correct-pm-max-children-settings-for-php-fpm/

Signed-off-by: Lance Albertson <lance@osuosl.org>
