### PR TITLE
Remove mod_php default conf file after installing

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -85,4 +85,8 @@ action :install do
       action :create_if_missing
     end
   end
+
+  directory '/etc/httpd/conf.modules.d' do
+    action :delete
+  end
 end


### PR DESCRIPTION
Installing mod_php with Remi on AlmaLinux 9 adds a default configuration file to `/etc/httpd/conf.modules.d`. Remove this to avoid idempotency issues with the `osl-apache` default recipe.