### PR TITLE
Remove `conf.d` directory after installing

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -90,4 +90,9 @@ action :install do
     recursive true
     action :delete
   end
+
+  directory '/etc/httpd/conf.d' do
+    recursive true
+    action :delete
+  end
 end

--- a/spec/unit/resources/install_spec.rb
+++ b/spec/unit/resources/install_spec.rb
@@ -42,6 +42,7 @@ describe 'osl_php_install' do
   end
 
   it { is_expected.to delete_directory('/etc/httpd/conf.modules.d') }
+  it { is_expected.to delete_directory('/etc/httpd/conf.d') }
 
   context 'Almalinux 8' do
     platform 'almalinux', '8'


### PR DESCRIPTION
Installing PHP 7.4 with Remi on AlmaLinux 9 adds a default configuration file to `/etc/httpd/conf.d`. Remove the directory to avoid idempotency issues with the `osl-apache` default recipe.