### PR TITLE
Add php_version support to osl_php_ini for Remi versioned installs

### DIFF
--- a/documentation/osl_php_ini.md
+++ b/documentation/osl_php_ini.md
@@ -10,8 +10,9 @@ This resource is used to create ini files for PHP configuration.
 
 ## Properties
 
-|  Name   |  Type  |  Default  |  Description                 |  Required?  |
-| :------ | :----: | :-------: | :----------------------------| :---------- |
-| mode    | String | '0644'    | Unix file mode of ini file.  | false       |
-| options | Hash   | `{}`      | A hash for configuring the ini file. A basic hash with keys and values of type String will be rendered as `'key'='value'` in the file. Nesting a basic hash so the key is type String and the value is another hash will create a section with the key as the name and the value as the section contents, still in the `'subkey'='subvalue'` format. | true        |
-| path    | String | Name      | Path to place ini file.      | true        |
+|  Name        |  Type  |  Default  |  Description                 |  Required?  |
+| :----------- | :----: | :-------: | :----------------------------| :---------- |
+| mode         | String | '0644'    | Unix file mode of ini file.  | false       |
+| options      | Hash   | `{}`      | A hash for configuring the ini file. A basic hash with keys and values of type String will be rendered as `'key'='value'` in the file. Nesting a basic hash so the key is type String and the value is another hash will create a section with the key as the name and the value as the section contents, still in the `'subkey'='subvalue'` format. | true        |
+| path         | String | Name      | Path to place ini file.      | true        |
+| php\_version | String |           | When set, places the ini file in the versioned Remi PHP config directory (`/etc/opt/remi/php{version}/php.d/`) instead of the default `/etc/php.d/`. Value should be a version string like `'8.4'`. | false       |

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -230,6 +230,23 @@ suites:
       inspec_tests:
         - test/integration/php-ini
 
+  - name: osl_php_ini_versioned
+    run_list:
+      - recipe[php_test::php_ini]
+    provisioner:
+      enforce_idempotency: false
+      multiple_converge: 1
+    attributes:
+      php_test:
+        version: '8.4'
+    verifier:
+      inspec_tests:
+        - test/integration/php-ini
+      inputs:
+        version: '8.4'
+    excludes:
+      - almalinux-8
+
   - name: opcache-php72
     run_list:
       - recipe[php_test::packages]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -59,6 +59,15 @@ module OslPhp
       def osl_php_default_installation_packages_without_prefixes
         (php_installation_packages.map { |p| p[/^php[0-9u]*-(.*)/, 1] } - ['pear'] - [nil])
       end
+
+      def osl_php_ini_config_dir(version = nil)
+        if version
+          shortver = version.delete('.')
+          "/etc/opt/remi/php#{shortver}/php.d"
+        else
+          '/etc/php.d'
+        end
+      end
     end
   end
 end

--- a/resources/ini.rb
+++ b/resources/ini.rb
@@ -6,13 +6,17 @@ default_action :add
 
 property :mode, String, default: '0644'
 property :options, Hash, required: [:add]
+property :php_version, String
 
 action :add do
-  directory "/etc/php.d #{new_resource.name}" do
-    path '/etc/php.d'
+  config_dir = osl_php_ini_config_dir(new_resource.php_version)
+
+  directory "#{config_dir} #{new_resource.name}" do
+    path config_dir
+    recursive true
   end
 
-  template "/etc/php.d/#{new_resource.name}.ini" do
+  template "#{config_dir}/#{new_resource.name}.ini" do
     source 'php_ini.erb'
     cookbook 'osl-php'
     variables data: new_resource.options
@@ -21,7 +25,9 @@ action :add do
 end
 
 action :remove do
-  file "/etc/php.d/#{new_resource.name}.ini" do
+  config_dir = osl_php_ini_config_dir(new_resource.php_version)
+
+  file "#{config_dir}/#{new_resource.name}.ini" do
     action :delete
   end
 end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -28,6 +28,7 @@ action :install do
   if new_resource.use_opcache
     osl_php_ini '10-opcache' do
       options osl_php_opcache_conf.merge!(new_resource.opcache_conf)
+      php_version version if new_resource.versioned_packages
     end
   end
 
@@ -75,6 +76,7 @@ action :install do
 
   osl_php_ini 'timezone' do
     options('date.timezone' => 'UTC')
+    php_version version if new_resource.versioned_packages
   end
 
   %w(phpcheck phpshow).each do |file|

--- a/spec/unit/resources/ini_spec.rb
+++ b/spec/unit/resources/ini_spec.rb
@@ -60,4 +60,39 @@ describe 'osl_php_ini' do
 
     it { is_expected.to delete_file('/etc/php.d/remove.ini') }
   end
+
+  context 'versioned php' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_php_ini 'default' do
+        options('date.timezone' => 'UTC')
+        php_version '8.4'
+      end
+    end
+
+    it { is_expected.to add_osl_php_ini('default').with(options: { 'date.timezone' => 'UTC' }, php_version: '8.4') }
+    it { is_expected.to create_directory('/etc/opt/remi/php84/php.d default').with(path: '/etc/opt/remi/php84/php.d') }
+
+    it do
+      is_expected.to create_template('/etc/opt/remi/php84/php.d/default.ini').with(
+        source: 'php_ini.erb',
+        cookbook: 'osl-php',
+        mode: '0644'
+      )
+    end
+  end
+
+  context 'versioned php remove' do
+    cached(:subject) { chef_run }
+
+    recipe do
+      osl_php_ini 'remove' do
+        php_version '8.4'
+        action :remove
+      end
+    end
+
+    it { is_expected.to delete_file('/etc/opt/remi/php84/php.d/remove.ini') }
+  end
 end

--- a/spec/unit/resources/install_spec.rb
+++ b/spec/unit/resources/install_spec.rb
@@ -219,4 +219,46 @@ describe 'osl_php_install' do
       it { is_expected.to install_package('php-pear') }
     end
   end
+
+  context 'versioned_packages' do
+    platform 'almalinux', '9'
+    step_into :osl_php_install
+
+    cached(:chef_run) do
+      chef_runner.converge('php_test::blank') do
+        recipe = Chef::Recipe.new('test', '_test', chef_runner.run_context)
+
+        recipe.instance_exec do
+          osl_php_install 'versioned' do
+            versioned_packages true
+            version '8.4'
+            php_packages %w(devel fpm gd)
+          end
+        end
+      end
+    end
+
+    it { is_expected.to add_osl_php_ini('timezone').with(options: { 'date.timezone' => 'UTC' }, php_version: '8.4') }
+    it { is_expected.to create_yum_remi_safe('default') }
+    it { is_expected.to install_php_install('versioned all packages').with(packages: %w(php84-php-devel php84-php-fpm php84-php-gd php84-php)) }
+
+    context 'with opcache' do
+      cached(:chef_run) do
+        chef_runner.converge('php_test::blank') do
+          recipe = Chef::Recipe.new('test', '_test', chef_runner.run_context)
+
+          recipe.instance_exec do
+            osl_php_install 'versioned with opcache' do
+              versioned_packages true
+              version '8.4'
+              php_packages %w(devel)
+              use_opcache true
+            end
+          end
+        end
+      end
+
+      it { is_expected.to add_osl_php_ini('10-opcache').with(php_version: '8.4') }
+    end
+  end
 end

--- a/test/cookbooks/php_test/recipes/php_ini.rb
+++ b/test/cookbooks/php_test/recipes/php_ini.rb
@@ -102,19 +102,25 @@ no_sections = {
   'session.cache_expire' => '180',
 }
 
+version = node['php_test']['version']
+
 osl_php_ini 'with_sections_rendered' do
   options with_sections
+  php_version version if version
 end
 
 osl_php_ini 'no_sections_rendered' do
   options no_sections
+  php_version version if version
 end
 
 osl_php_ini 'no_sections_rendered_added' do
   options no_sections
+  php_version version if version
 end
 
 osl_php_ini 'no_sections_rendered_removed' do
+  php_version version if version
   action :remove
 end
 

--- a/test/integration/multi-php/controls/multi_php_control.rb
+++ b/test/integration/multi-php/controls/multi_php_control.rb
@@ -79,3 +79,17 @@ control 'remi php version 2 binary' do
     its('stdout') { should match version2 }
   end
 end
+
+control 'versioned php ini files' do
+  title 'Verify ini files are placed in versioned config directories'
+
+  describe file("/etc/opt/remi/php#{short_version1}/php.d/timezone.ini") do
+    it { should exist }
+    its('content') { should match 'date.timezone=UTC' }
+  end
+
+  describe file("/etc/opt/remi/php#{short_version2}/php.d/timezone.ini") do
+    it { should exist }
+    its('content') { should match 'date.timezone=UTC' }
+  end
+end

--- a/test/integration/php-ini/controls/php-ini_control.rb
+++ b/test/integration/php-ini/controls/php-ini_control.rb
@@ -1,21 +1,29 @@
 # Include selinux test
 include_controls 'selinux'
 
+version = input('version', value: '')
+
+php_dir = if version.empty?
+            '/etc/php.d'
+          else
+            "/etc/opt/remi/php#{version.delete('.')}/php.d"
+          end
+
 control 'php-ini' do
   title 'Verify php ini files are correct'
 
   no_sections_static = inspec.file('/tmp/no_sections_static').content
   with_sections_static = inspec.file('/tmp/with_sections_static').content
 
-  describe file('/etc/php.d/no_sections_rendered.ini') do
+  describe file("#{php_dir}/no_sections_rendered.ini") do
     its('content') { should match no_sections_static }
   end
 
-  describe file('/etc/php.d/with_sections_rendered.ini') do
+  describe file("#{php_dir}/with_sections_rendered.ini") do
     its('content') { should match with_sections_static }
   end
 
-  describe file('/etc/php.d/no_sections_rendered_removed.ini') do
+  describe file("#{php_dir}/no_sections_rendered_removed.ini") do
     it { should_not exist }
   end
 end

--- a/test/integration/versioned-packages/controls/versioned_packages_control.rb
+++ b/test/integration/versioned-packages/controls/versioned_packages_control.rb
@@ -46,3 +46,12 @@ control 'multiple php versions available' do
     its('exit_status') { should eq 0 }
   end
 end
+
+control 'versioned php ini' do
+  title 'Verify ini files are placed in the versioned config directory'
+
+  describe file("/etc/opt/remi/php#{short_version}/php.d/timezone.ini") do
+    it { should exist }
+    its('content') { should match 'date.timezone=UTC' }
+  end
+end


### PR DESCRIPTION
When using versioned_packages with osl_php_install, ini files are now
placed in /etc/opt/remi/phpXX/php.d/ instead of /etc/php.d/.

- Add php_version property to osl_php_ini resource
- Add osl_php_ini_config_dir helper to libraries/helpers.rb
- Pass php_version from osl_php_install when versioned_packages is true
- Add versioned php_ini integration test suite
- Update integration tests for versioned-packages and multi-php
- Update documentation and unit tests

Signed-off-by: Lance Albertson <lance@osuosl.org>
