### PR TITLE
Allow composer to upgrade when a new release is available

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -93,7 +93,6 @@ action :install do
     remote_file '/usr/local/bin/composer' do
       source composer_url
       mode '755'
-      action :create_if_missing
     end
   end
 

--- a/spec/unit/resources/install_spec.rb
+++ b/spec/unit/resources/install_spec.rb
@@ -140,7 +140,7 @@ describe 'osl_php_install' do
       end
     end
     it do
-      is_expected.to create_if_missing_remote_file('/usr/local/bin/composer').with(
+      is_expected.to create_remote_file('/usr/local/bin/composer').with(
         source: 'https://getcomposer.org/download/2.9.5/composer.phar',
         mode: '755'
       )
@@ -160,7 +160,7 @@ describe 'osl_php_install' do
         end
       end
       it do
-        is_expected.to create_if_missing_remote_file('/usr/local/bin/composer').with(
+        is_expected.to create_remote_file('/usr/local/bin/composer').with(
           source: 'https://getcomposer.org/download/2.9.5/composer.phar'
         )
       end


### PR DESCRIPTION
- Drop :create_if_missing on the composer remote_file so the default
  :create action runs; composer was never updated after the initial
  install even though the default composer_version tracks the latest
  2.x release
- A new release changes the source URL, triggering a re-download;
  conditional GET keeps unchanged runs a no-op
- Update ChefSpec matchers to create_remote_file

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>
